### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,9 @@
 
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/DwaineDGIlmer/AiEventing/security/code-scanning/1](https://github.com/DwaineDGIlmer/AiEventing/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to explicitly limit the permissions granted to the GITHUB_TOKEN. The best way to do this is to add the block at the root level of the workflow file, so it applies to all jobs unless overridden. For this workflow, which only checks out code and builds/tests it, the minimal required permission is `contents: read`. This change should be made near the top of the file, after the `name` and before the `on` block (or immediately after the `on` block if you prefer). No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
